### PR TITLE
fixed fast ADC

### DIFF
--- a/controller/LED.h
+++ b/controller/LED.h
@@ -289,8 +289,7 @@ public:
         // external light
         if(_control & (1<<LIGHT))
         {
-            uint16_t value = EXTLIGHT;
-            value = (value)>>2;
+            uint8_t value = EXTLIGHT;
             if(value > _brightness[LIGHT])
             {
                 digitalWrite(_pin, LOW);
@@ -343,25 +342,24 @@ public:
         // bass routing
         if(_control & (1<<BASS))
         {
-            uint16_t value = GETBASS;
+            Serial.println(micros());
             // value is a 10 bit number, drop some bits to accomodate for set colour depth
-            _brightness[BASS] = (value)>>(10 - _colourDepth);
+            _brightness[BASS] = GETBASS;
+            Serial.println(micros());
         }
 
         // mid routing
         if(_control & (1<<MID))
         {
-            uint16_t value = GETMID;
             // value is a 10 bit number, drop some bits to accomodate for set colour depth
-            _brightness[MID] = (value)>>(10 - _colourDepth);
+            _brightness[MID] = GETMID;
         }
 
         // treble routing
         if(_control & (1<<TREBLE))
         {
-            uint16_t value = GETTREBLE;
             // value is a 10 bit number, drop some bits to accomodate for set colour depth
-            _brightness[TREBLE] = (value)>>(10 - _colourDepth);
+            _brightness[TREBLE] = GETTREBLE;
         }
 
         float totalBrightness = 0;

--- a/controller/controller.ino
+++ b/controller/controller.ino
@@ -3,41 +3,52 @@
 //String red = "", green = "", blue = "";
 //SoftwareSerial blt(8,7);
 
+void setupADC()
+{
+    ADMUX |= (1 << REFS0);  // set reference voltage
+    ADMUX |= (1 << ADLAR);  // left align ADC value to 8 bits from ADCH register
+    ADCSRA |= (1 << ADPS2);                     // 16 prescaler for 76.9 KHz
+    // ADCSRA |= (1 << ADPS1) | (1 << ADPS0);    // 8 prescaler for 153.8 KHz
+    ADCSRA |= (1 << ADEN);  // enable ADC
+}
+
 LED Red(9);
 LED Green(10);
 LED Blue(11);
 
 void setup()
-{ 
-//    blt.begin(9600);
-//    Serial.begin(115200);
-//    pinMode(IND, OUTPUT);
+{
+    setupADC();
     
-    Red.setTime(500, 1000);
+    // blt.begin(9600);
+    Serial.begin(115200);
+    pinMode(IND, OUTPUT);
+    
+    Red.setTime(5000, 5000);
     Green.setTime(1000,2500);
     Blue.setTime(1500,500);
     
+    // Red.invert(true);
     // Red.pulse(true);
-    Red.invert(true);
-    Red.setColourDepth(8);
+    // Red.setColourDepth(8);
     // Red.watchExternalLight(true,127);
-    // Red.routeBass(true);
+    Red.routeBass(true);
     // Red.routeUser(true);
     // Red.setUserBrightness(255);
     // Serial.println(Red.getActiveChannels());
     
-    Green.pulse(true);
+    // Green.pulse(true);
     // Green.limit(160);
-    Green.setColourDepth(8);
+    // Green.setColourDepth(8);
     // Green.watchExternalLight(true,200);
-    // Green.routeMid(true);
+    Green.routeMid(true);
     // Green.routeUser(true);
     // Green.setUserBrightness(255);
     // Serial.println(Green.getActiveChannels());
     
     // Blue.flash(true);
-    Blue.invert(true);
-    Blue.setColourDepth(8);
+    // Blue.invert(true);
+    // Blue.setColourDepth(8);
     // Blue.watchExternalLight(true,127);
     // Blue.routeTreble(true);
     // Blue.routeUser(true);

--- a/controller/definitions.h
+++ b/controller/definitions.h
@@ -6,14 +6,15 @@
 #define IND 13
 #define INDON digitalWrite(IND, HIGH);
 #define INDOFF digitalWrite(IND, LOW);
-#define BASSPIN A0
-#define MIDPIN A1
-#define TREBLEPIN A2
-#define LDRPIN A3
-#define GETBASS analogRead8bit(BASSPIN)
-#define GETMID analogRead8bit(MIDPIN)
-#define GETTREBLE analogRead8bit(TREBLEPIN)
-#define EXTLIGHT analogRead(LDRPIN)
+#define BASSPIN 0
+#define MIDPIN 1
+#define TREBLEPIN 2
+#define LDRPIN 3
+#define ANALOGREAD analogRead8bit
+#define GETBASS ANALOGREAD(BASSPIN)
+#define GETMID ANALOGREAD(MIDPIN)
+#define GETTREBLE ANALOGREAD(TREBLEPIN)
+#define EXTLIGHT ANALOGREAD(LDRPIN)
 
 enum positions {LIGHT, TREBLE, MID, BASS, USER, PULSE, FLASH, TOTAL};
 
@@ -23,29 +24,16 @@ enum positions {LIGHT, TREBLE, MID, BASS, USER, PULSE, FLASH, TOTAL};
 uint8_t analogRead8bit(uint8_t pin)
 {
 	uint8_t result;
-
-	// set ADLAR high
-	ADMUX |= _BV(ADLAR);
-
-#if defined(ADMUX)
 	ADMUX |= (pin & 0x07);
-#endif
 
-#if defined(ADCSRA) && defined(ADCL)
-	// start the conversion
-	ADCSRA |= _BV(ADSC);
+  	// start the conversion
+	ADCSRA |= (1<<ADSC);
 
 	// ADSC is cleared when the conversion finishes
 	while (bit_is_set(ADCSRA, ADSC));
 
 	//read only ADCH, 8 bits
 	result = ADCH;
-#else
-	// we don't have an ADC, return 0
-	result = 0;
-#endif
-
-	// combine the two bytes
 	return result;
 }
 


### PR DESCRIPTION
* ADEN and REFV were not set earlier
* this fix renders the current implementation of colourDepth obsolete
* Next patches shall speed-up brightness arithmetic and usage of colour depth